### PR TITLE
Upgrade to latest version of jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "coffee-script": "^1.10.0",
-    "jsdom": "^8.1.0",
+    "jsdom": "^11.6.0",
     "mocha": "^2.3.4"
   }
 }

--- a/test/planerHtml.test.coffee
+++ b/test/planerHtml.test.coffee
@@ -10,7 +10,7 @@ describe 'planer#extractFromHtml', ->
       FetchExternalResources: false,
       ProcessExternalResources: false
     }
-    @dom = jsdom.jsdom('')
+    @dom = new jsdom.JSDOM().window.document
 
   it 'should return an empty body when given an empty body', ->
     msgBody = ''


### PR DESCRIPTION
In jsdom > 10.x.x, `jsdom.jsdom('')` was deprecated and replaced with a `JSDOM` class that wraps `window` with some extra functionality. This PR upgrades to the latest version of `jsdom` and updates the instantiation pattern.