### PR TITLE
Update package.json registry to use https.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Remove reply quotations from emails",
   "main": "lib/planer.js",
   "publishConfig": {
-    "registry": "http://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
     "test": "mocha test/",


### PR DESCRIPTION
Small change to avoid running into an TLS error when trying to publish the package with the older unencrypted http endpoint.